### PR TITLE
Extend test suite with maintainer mode tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ before_install:
 before_script:
 - ./autogen.sh
 - mkdir build && cd build
-- ../configure --enable-coverage --disable-shared --disable-silent-rules --with-bundled-json --with-bundled-spdlog
+- ../configure --enable-maintainer-mode --enable-coverage --disable-shared --disable-silent-rules --with-bundled-json --with-bundled-spdlog
 script:
 - make && make check && make analyze-clang
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,40 +2,66 @@ env:
   global:
   - secure: ZmM4qgsgTYcxgDaQQMhphPerUo9SYm2TKyxzA07ArEZf9Ur10taagze/sueNa4g5TxeoynxpxeyoUvPpqPrucNPE70uFimH1TW55Hi3WWzBVwNfvLFXIBUcXAmVi3BalNAXJvhyjZgRwP+39wRkJG2V9vZjtDzB7umb0RPjbwBs=
 language: cpp
-sudo: required
-dist: trusty
 compiler:
 - clang
 - gcc
 os: linux
+dist: trusty
+sudo: required
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5']
+      env: COMPILER=g++-5
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-6']
+      env: COMPILER=g++-6
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
+          packages: ['clang-3.8']
+      env: COMPILER=clang++-3.8
+    - os: linux
+      compiler: gcc
+      env: COVERAGE=yes CONFIGURE_ARGS="--enable-coverage --disable-shared"
+    - os: linux
+      compiler: gcc
+      env: MAKE_TARGET=distcheck
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          packages: ['clang']
+      env: MAKE_TARGET=analyze-clang
+    - os: linux
+      compiler: clang
+      env: CONFIGURE_ARGS=--enable-asan
+    - os: linux
+      compiler: gcc
+      env: CONFIGURE_ARGS=--enable-debug-build
 before_install:
 - sudo add-apt-repository -y ppa:chris-lea/libsodium
 - sudo apt-get -qq update
 - sudo apt-get install -y libudev-dev libsodium-dev libqb-dev libcap-ng-dev libseccomp-dev
 - sudo apt-get install -y qtbase5-dev qt5-default qtbase5-dev-tools
+- sudo apt-get install -y libglib2.0-dev libdbus-glib-1-dev libxml2-utils libpolkit-gobject-1-dev xsltproc
 - sudo apt-get install -y lcov
-- sudo apt-get install -y clang
-- sudo apt-get install -y libglib2.0-dev libdbus-glib-1-dev libxml2-utils
-- sudo apt-get install -y libpolkit-gobject-1-dev
-- sudo apt-get install -y xsltproc
 - gem install coveralls-lcov
 before_script:
 - ./autogen.sh
 - mkdir build && cd build
-- ../configure --enable-maintainer-mode --enable-coverage --disable-shared --disable-silent-rules --with-bundled-json --with-bundled-spdlog
+- CXX=$COMPILER ../configure --enable-maintainer-mode --disable-silent-rules --with-bundled-json --with-bundled-spdlog $CONFIGURE_ARGS
 script:
-- make && make check && make analyze-clang
-addons:
-  coverity_scan:
-    project:
-      name: dkopecek/usbguard
-      version: 0.4
-      description: USBGuard
-    notification_email: dnk1618@gmail.com
-    build_command_prepend: "./autogen.sh && ./configure"
-    build_command: make
-    branch_pattern: coverity_scan
+- if test -n "$MAKE_TARGET"; then make $MAKE_TARGET; else make all check; fi
 after_success:
-- lcov --compat-libtool --directory . --capture --output-file coverage.info
-- coveralls-lcov coverage.info
-
+- test "x$COVERAGE" = xyes -a "x$CXX" = "xg++" && lcov --compat-libtool --directory . --capture --output-file coverage.info && coveralls-lcov coverage.info

--- a/Makefile.am
+++ b/Makefile.am
@@ -454,3 +454,14 @@ analyze-clang:
 	  make -j$(JOBS)
 	rm -rf "$(ANALYSIS_ROOT)"
 
+if MAINTAINER_MODE
+check-local: check-copyright
+
+check-copyright:
+	$(eval GIT_CLONE_ROOT:=$(shell mktemp -d -t usbguard-git-clone.XXXXXX))
+	git clone . "$(GIT_CLONE_ROOT)" && \
+	  src/Tests/Packaging/files-without-copyright.sh "$(GIT_CLONE_ROOT)"
+	rm -rf "$(GIT_CLONE_ROOT)"
+else
+check-local:
+endif

--- a/configure.ac
+++ b/configure.ac
@@ -327,6 +327,15 @@ if test "x$enable_tsan" = xyes; then
   # We can't do anything about this message in GCC; use clang.
 fi
 
+#
+# Maintainer mode.
+#
+# Runs several additional taks for certain make targets (e.g. tests)
+#
+AC_ARG_ENABLE([maintainer-mode],
+              [AS_HELP_STRING([--enable-maintainer-mode], [Enable maintainer mode (default=no)])],
+              [maintainer_mode=$enableval], [maintainer_mode=no])
+
 # Checks for header files.
 AC_FUNC_ALLOCA
 AC_CHECK_HEADERS([arpa/inet.h fcntl.h inttypes.h limits.h locale.h netdb.h stdint.h stdlib.h string.h sys/time.h syslog.h unistd.h wchar.h])
@@ -406,6 +415,7 @@ AM_CONDITIONAL([SYSTEMD_SUPPORT_ENABLED], [test "x$systemd" = xyes ])
 AM_CONDITIONAL([GUI_QT5_ENABLED], [test "x$with_gui_qt5" = xyes ])
 AM_CONDITIONAL([DBUS_ENABLED], [test "x$with_dbus" = xyes ])
 AM_CONDITIONAL([POLICYKIT_ENABLED], [test "x$with_polkit" = xyes])
+AM_CONDITIONAL([MAINTAINER_MODE], [test "x$maintainer_mode" = xyes])
 
 AC_CONFIG_FILES([Makefile
                  src/Tests/Makefile
@@ -416,6 +426,8 @@ AC_OUTPUT
 echo
 echo "    Build Configuration Summary    "
 echo "==================================="
+echo
+echo " Maintainer mode: $maintainer_mode"
 echo
 echo "## Libraries"
 echo

--- a/src/Tests/Makefile.am
+++ b/src/Tests/Makefile.am
@@ -4,7 +4,8 @@ AM_CPPFLAGS=\
 	-I$(top_srcdir)/src/ThirdParty/Catch/include
 
 EXTRA_DIST=\
-	$(top_srcdir)/src/ThirdParty/Catch
+	$(top_srcdir)/src/ThirdParty/Catch \
+	$(top_srcdir)/src/Tests/Packaging/files-without-copyright.sh
 
 TESTS=\
 	test-unit \

--- a/src/Tests/Packaging/files-without-copyright.sh
+++ b/src/Tests/Packaging/files-without-copyright.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+#
+# Copyright (C) 2016 Red Hat, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Authors: Daniel Kopecek <dkopecek@redhat.com>
+#
+#
+# This script looks for files that don't contain copyright infomation.
+# It does so very naively by searching for files that do not contain
+# "Copyright " in their contents.
+#
+##################
+GLOBS_INCLUDE=(
+*.[ch]pp
+*.am
+*.y
+*.qx
+*.qrc
+*.sh
+)
+
+GLOBS_EXCLUDE=(
+)
+
+DIRS_EXCLUDE=(
+ThirdParty
+)
+##################
+if [[ -z "$1" ]]; then
+  echo "Usage: $(basename $0) <search-root-dir>"
+  exit 1
+fi
+
+GREP_ROOT="$1"
+GREP_PATTERN="Copyright "
+GREP_ARGS=""
+
+for glob in ${GLOBS_INCLUDE[*]}; do
+GREP_ARGS+=" --include=$glob"
+done
+
+for glob in ${GLOBS_EXCLUDE[*]}; do
+GREP_ARGS+=" --exclude=$glob"
+done
+
+for dir in ${DIRS_EXCLUDE[*]}; do
+GREP_ARGS+=" --exclude-dir=$dir"
+done
+
+FILELIST=$(cd $GREP_ROOT && grep -Lr $GREP_PATTERN . $GREP_ARGS)
+
+if [[ $? -ne 0 ]]; then
+  exit 1
+fi
+
+if [[ -z "$FILELIST" ]]; then
+  exit 0
+fi
+
+echo '#'
+echo '# The following files seem not to contain copyright information:'
+echo '#'
+echo -e "$FILELIST"
+
+exit 1


### PR DESCRIPTION
 - added --enable-maintainer-mode option to the configure script
 - added checking of copyright header presence in files
 - run travis CI tests in maintainer mode

Related: #78