### PR TITLE
[travis-ci] Refactoring of the .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,40 +2,66 @@ env:
   global:
   - secure: ZmM4qgsgTYcxgDaQQMhphPerUo9SYm2TKyxzA07ArEZf9Ur10taagze/sueNa4g5TxeoynxpxeyoUvPpqPrucNPE70uFimH1TW55Hi3WWzBVwNfvLFXIBUcXAmVi3BalNAXJvhyjZgRwP+39wRkJG2V9vZjtDzB7umb0RPjbwBs=
 language: cpp
-sudo: required
-dist: trusty
 compiler:
 - clang
 - gcc
 os: linux
+dist: trusty
+sudo: required
+matrix:
+  include:
+    - os: linux
+      compiler: gcc
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-5']
+      env: COMPILER=g++-5
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test']
+          packages: ['g++-6']
+      env: COMPILER=g++-6
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          sources: ['ubuntu-toolchain-r-test', 'llvm-toolchain-precise-3.8']
+          packages: ['clang-3.8']
+      env: COMPILER=clang++-3.8
+    - os: linux
+      compiler: gcc
+      env: COVERAGE=yes CONFIGURE_ARGS="--enable-coverage --disable-shared"
+    - os: linux
+      compiler: gcc
+      env: MAKE_TARGET=distcheck
+    - os: linux
+      compiler: clang
+      addons:
+        apt:
+          packages: ['clang']
+      env: MAKE_TARGET=analyze-clang
+    - os: linux
+      compiler: clang
+      env: CONFIGURE_ARGS=--enable-asan
+    - os: linux
+      compiler: gcc
+      env: CONFIGURE_ARGS=--enable-debug-build
 before_install:
 - sudo add-apt-repository -y ppa:chris-lea/libsodium
 - sudo apt-get -qq update
 - sudo apt-get install -y libudev-dev libsodium-dev libqb-dev libcap-ng-dev libseccomp-dev
 - sudo apt-get install -y qtbase5-dev qt5-default qtbase5-dev-tools
+- sudo apt-get install -y libglib2.0-dev libdbus-glib-1-dev libxml2-utils libpolkit-gobject-1-dev xsltproc
 - sudo apt-get install -y lcov
-- sudo apt-get install -y clang
-- sudo apt-get install -y libglib2.0-dev libdbus-glib-1-dev libxml2-utils
-- sudo apt-get install -y libpolkit-gobject-1-dev
-- sudo apt-get install -y xsltproc
 - gem install coveralls-lcov
 before_script:
 - ./autogen.sh
 - mkdir build && cd build
-- ../configure --enable-coverage --disable-shared --disable-silent-rules
+- CXX=$COMPILER ../configure --disable-silent-rules --with-bundled-json --with-bundled-spdlog $CONFIGURE_ARGS
 script:
-- make && make check && make analyze-clang
-addons:
-  coverity_scan:
-    project:
-      name: dkopecek/usbguard
-      version: 0.4
-      description: USBGuard
-    notification_email: dnk1618@gmail.com
-    build_command_prepend: "./autogen.sh && ./configure"
-    build_command: make
-    branch_pattern: coverity_scan
+- if test -n "$MAKE_TARGET"; then make $MAKE_TARGET; else make all check; fi
 after_success:
-- lcov --compat-libtool --directory . --capture --output-file coverage.info
-- coveralls-lcov coverage.info
-
+- test "x$COVERAGE" = xyes -a "x$CXX" = "xg++" && lcov --compat-libtool --directory . --capture --output-file coverage.info && coveralls-lcov coverage.info

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,14 +9,20 @@ BUILT_SOURCES=
 DISTCLEANFILES=
 CLEANFILES=
 
+install-data-hook: install-systemd-service install-data-dbus
+uninstall-hook: uninstall-systemd-service uninstall-data-dbus
+
 if SYSTEMD_SUPPORT_ENABLED
-install-data-hook:
+install-systemd-service:
 	mkdir -p $(DESTDIR)$(SYSTEMD_UNIT_DIR)
 	$(INSTALL) -m 644 $(top_srcdir)/dist/usbguard.service \
 	 $(DESTDIR)$(SYSTEMD_UNIT_DIR)/usbguard.service
 
-uninstall-hook:
+uninstall-systemd-service:
 	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/usbguard.service
+else
+install-systemd-service:
+uninstall-systemd-service:
 endif
 
 dist_man8_MANS=\
@@ -275,13 +281,13 @@ usbguard_dbus_LDADD=\
 %.service: %.service.in
 	sed -e "s|%{sbindir}%|$(sbindir)|" "$<" > "$(top_builddir)/$@"
 
-install-data-local: $(top_builddir)/src/DBus/org.usbguard.service install-polkit-policy install-systemd-service
+install-data-dbus: $(top_builddir)/src/DBus/org.usbguard.service install-polkit-policy install-systemd-dbus-service
 	mkdir -p $(DESTDIR)$(DBUS_SERVICES_DIR) && \
 	  $(INSTALL_DATA) $(top_builddir)/src/DBus/org.usbguard.service $(DESTDIR)$(DBUS_SERVICES_DIR)
 	mkdir -p $(DESTDIR)$(DBUS_BUSCONFIG_DIR) && \
 	  $(INSTALL_DATA) $(top_srcdir)/src/DBus/org.usbguard.conf $(DESTDIR)$(DBUS_BUSCONFIG_DIR)
 
-uninstall-local: uninstall-polkit-policy uninstall-systemd-service
+uninstall-data-dbus: uninstall-polkit-policy uninstall-systemd-dbus-service
 	rm -f $(DESTDIR)$(DBUS_SERVICES_DIR)/org.usbguard.service
 	rmdir $(DESTDIR)$(DBUS_SERVICES_DIR)
 	rm -f $(DESTDIR)$(DBUS_BUSCONFIG_DIR)/org.usbguard.conf
@@ -319,18 +325,21 @@ uninstall-polkit-policy:
 endif
 
 if SYSTEMD_SUPPORT_ENABLED
-install-systemd-service: $(top_builddir)/src/DBus/usbguard-dbus.service
+install-systemd-dbus-service: $(top_builddir)/src/DBus/usbguard-dbus.service
 	mkdir -p $(DESTDIR)$(SYSTEMD_UNIT_DIR) && \
 	  $(INSTALL_DATA) $(top_builddir)/src/DBus/usbguard-dbus.service $(DESTDIR)$(SYSTEMD_UNIT_DIR)
 
-uninstall-systemd-service:
+uninstall-systemd-dbus-service:
 	rm -f $(DESTDIR)$(SYSTEMD_UNIT_DIR)/usbguard-dbus.service
 	rmdir $(DESTDIR)$(SYSTEMD_UNIT_DIR)
 
 else
-install-systemd-service:
-uninstall-systemd-service:
+install-systemd-dbus-service:
+uninstall-systemd-dbus-service:
 endif
+else
+install-data-dbus:
+uninstall-data-dbus:
 endif #DBUS_ENABLED
 
 #

--- a/configure.ac
+++ b/configure.ac
@@ -225,6 +225,22 @@ if test "x$with_dbus" = xyes; then
   if test "x$dbus_services_dir" = x; then
     AC_MSG_FAILURE([Cannot autodetect the D-Bus system services directory])
   else
+    #
+    # Hack around expanded paths in system_bus_services_dir. Without this distcheck won't
+    # work, because it uses ./configure --prefix=$somedir. The expanded path ignores this
+    # prefix (and DESTDIR won't help here either)
+    #
+    case "$dbus_services_dir" in
+      /usr/share/*|/usr/local/share/*)
+        dbus_services_dir=$(sed -r 's,^(/usr/share|/usr/local/share),${datadir},'<<<$dbus_services_dir)
+      ;;
+      /usr/*|/usr/local/*)
+        dbus_services_dir=$(sed -r 's,^(/usr|/usr/local),${prefix},'<<<$dbus_services_dir)
+      ;;
+      /*)
+        dbus_services_dir='${prefix}'"$dbus_services_dir"
+      ;;
+    esac
     AC_SUBST(DBUS_SERVICES_DIR, $dbus_services_dir)
     AC_DEFINE([DBUS_SERVICES_DIR], [$dbus_services_dir], [D-Bus system services directory])
   fi


### PR DESCRIPTION
 - test against multiple compiler versions (e.g. gcc 6)
 - test distcheck
 - dropped coverity integration for now (wasn't working lately)
 - run the analyze-clang target
 - don't require sudo
 - allow to specify configure args and the make target via env