### PR TITLE
Makefile.am: remove CPPFLAGS from moc

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -468,7 +468,7 @@ usbguard_applet_qt_CPPFLAGS=\
 	-fPIC @qt5_CFLAGS@
 
 %.moc.cpp: %.h
-	@MOCQT5@ -f"$(shell basename $<)" -I$(top_srcdir)/src/GUI.Qt5 -o$(top_builddir)/$@ $(DEFS) $(DEFAULT_INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(MOC_CPPFLAGS) $<
+	@MOCQT5@ -f"$(shell basename $<)" -I$(top_srcdir)/src/GUI.Qt5 -o$(top_builddir)/$@ $(DEFS) $(DEFAULT_INCLUDES) $(MOC_CPPFLAGS) $<
 
 %.ui.h: %.ui
 	@UICQT5@ -g cpp -o $(top_builddir)/$@ $<


### PR DESCRIPTION
moc doesn't know `-Wdate-time` which is part of the CPPFLAGS on debian to achieve reproducable builds (https://gcc.gnu.org/gcc-4.9/changes.html#languages: "warns when the __DATE__, __TIME__ or __TIMESTAMP__ macros are used. Those macros might prevent bit-wise-identical reproducible compilations.")
i'm not sure if there are CPPFLAGS needed by moc. also not sure if this could also happen with AM_CPPFLAGS