### PR TITLE
processDeviceInsertion: Reject only if an exception occurred, not always

### DIFF
--- a/src/Library/LinuxDeviceManager.cpp
+++ b/src/Library/LinuxDeviceManager.cpp
@@ -495,6 +495,7 @@ namespace usbguard {
       Pointer<LinuxDevice> device = makePointer<LinuxDevice>(*this, dev);
       insertDevice(device);
       DeviceInserted(device);
+      return;
     }
     catch(const std::exception& ex) {
       logger->error("Exception caught during device insertion processing: {}: {}", sys_path, ex.what());


### PR DESCRIPTION
Commit d15d5fac50f419021e6835499901e50d43119e46 moved the "reject device" (intended for devices that trigger an exception, e.g. malformed descriptor) in processDeviceInsertion out of the catch block; this causes *all* newly inserted devices (even allowed ones) to be rejected.