### PR TITLE
fix build on mips

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -133,7 +133,8 @@ libusbguard_la_LIBADD=\
 	@protobuf_LIBS@ \
 	@udev_LIBS@ \
 	@crypto_LIBS@ \
-	@pegtl_LIBS@
+	@pegtl_LIBS@ \
+	@atomic_LIBS@
 
 EXTRA_DIST+=\
 	src/Library/IPC/Devices.proto \

--- a/configure.ac
+++ b/configure.ac
@@ -70,6 +70,22 @@ AC_PROG_MAKE_SET
 AM_PROG_LIBTOOL
 AC_PROG_LIBTOOL
 
+# Check if libatomic is available, might be required for emulating
+# atomic intrinsics on some platforms.
+#
+AC_CHECK_LIB([atomic], [__atomic_add_fetch_8], [
+    __saved_LIBS="$LIBS"
+    LIBS="$LIBS -Wl,--push-state,--as-needed,-latomic,--pop-state"
+    AC_LINK_IFELSE([AC_LANG_PROGRAM()],
+      [atomic_LIBS="-Wl,--push-state,--as-needed,-latomic,--pop-state"],
+      [atomic_LIBS="-latomic"]
+    )
+    LIBS="$__saved_LIBS"
+], [atomic_LIBS=""])
+AC_SUBST([atomic_LIBS])
+
+#
+
 #
 # Checks for required libraries.
 #


### PR DESCRIPTION
this came up during the automated build for debian on mips (see bugreport https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=836712)

Christian Seiler explained the problem and provided the patch (https://lists.debian.org/debian-mentors/2016/09/msg00075.html and https://lists.debian.org/debian-mentors/2016/09/msg00084.html):
MIPS (at least 32bit) doesn't support 64bit atomic operations intrinsically (_8 == 8 bytes). However, gcc provides an emulation library called libatomic. This patch checks for the availability of libatomic and adds it to the linker flags.