### PR TITLE
Fix typos in documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,9 +61,9 @@
 ### Added
 - Maintainer script for spellchecking source archive files
 - Rule::Attribute class for representing the rule attributes
-- USBDeviceID class for represing the USB device ID
+- USBDeviceID class for representing the USB device ID
 - configure script option to control the bundling of PEGTL source files
-- id attribute to the rule language for specifing the USB device ID
+- id attribute to the rule language for specifying the USB device ID
 - Added a parent device ID field (and methods) to the Device class which
   tracks the ID of the parent device
 - Implemented "parent-hash" attribute for associating a device with its

--- a/NOTES.md
+++ b/NOTES.md
@@ -32,7 +32,7 @@ usbguard auth generate-keypair --name "keyname"
 `--sign` authorize for signing devices
 `--verify` authorize for verification of device signatures
 `--policy` authorize for modification of the policy (ruleset)
-`--device` authorize for changing the runime device policy
+`--device` authorize for changing the runtime device policy
 `--device-implicit` authorize for changing of the runtime implicit device policy
 
 ### Working with device signatures

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Reprogramming  attacks ([BadUSB](https://srlabs.de/badusb/)) which change the ty
 Allowing to attach any USB device to the system exposes it to exploitation of bugs in USB interface drivers in the kernel.
 
 ### Use case #2: USB device blacklisting
-The USB protocol uses a classification system for the various types  of  interfaces a USB device can provide. If an user doesn't want to use a particular class of interfaces, he can block devices that want to communicate with the computer as an interface from that class.
+The USB protocol uses a classification system for the various types  of  interfaces a USB device can provide. If a user doesn't want to use a particular class of interfaces, he can block devices that want to communicate with the computer as an interface from that class.
 
 ### Use case #3: Triggering actions on USB device events
 The project makes possible to easily implement triggering of various actions when a particular USB device or USB device class is inserted, removed, etc. This feature might be used for example for auditing USB usage, screen locking (per-user via applet), etc.
@@ -145,7 +145,7 @@ To actually start the daemon, use:
 
 ## Rule Language
 
-The USBGuard daemon decides which USB device to authorize based on a policy defined by a set of rules. When an USB device is inserted into the system, the daemon scans the existing rules sequentially and when a matching rule is found, it either authorizes (**allows**), deauthorizes (**blocks**) or removes (**rejects**) the device, based on the rule target. If no matching rule is found, the decision is based on an implicit default target. This implicit default is to block the device until a decision is made by the user. The rule language grammar, expressed in a BNF-like syntax, is the following:
+The USBGuard daemon decides which USB device to authorize based on a policy defined by a set of rules. When a USB device is inserted into the system, the daemon scans the existing rules sequentially and when a matching rule is found, it either authorizes (**allows**), deauthorizes (**blocks**) or removes (**rejects**) the device, based on the rule target. If no matching rule is found, the decision is based on an implicit default target. This implicit default is to block the device until a decision is made by the user. The rule language grammar, expressed in a BNF-like syntax, is the following:
 
 ```
     rule ::= target attributes.
@@ -168,7 +168,7 @@ The target of a rule specifies whether the device will be authorized for use or 
 
 ### Device Specification
 
-Except the target, all the other fields of a rule need not be specified. Such a minimal rule will match any device and allows the policy creator to write an explicit default target. If no rule from the policy is applicable to the device, an implicit target configured in **usbguard-daemon.conf**(5) will be used. However, if one want's to narrow the applicability of a rule to a set of devices or one device only, it's possible to do so with device attributes and rule conditions.
+Except the target, all the other fields of a rule need not be specified. Such a minimal rule will match any device and allows the policy creator to write an explicit default target. If no rule from the policy is applicable to the device, an implicit target configured in **usbguard-daemon.conf**(5) will be used. However, if one wants to narrow the applicability of a rule to a set of devices or one device only, it's possible to do so with device attributes and rule conditions.
 
 #### Device Attributes
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,12 +2,12 @@
 
 ## 0.6.x
 
-- Resolve GCC 4.8.x combatibility
+- Resolve GCC 4.8.x compatibility
  - Reimplement json parsing/serialization on top of json-c
 - Revision of the logging code
  - Drop spdlog, implement a simple file/console/syslog logger
  - Allow custom logging handlers from third-party code
- - Use logging consistenly in the code
+ - Use logging consistently in the code
 - Investigate possibility of supporting comments in the rule file
 
 ## 0.7.x
@@ -27,5 +27,5 @@
 
 - First stable release
 - No backwards incompatible changes from this point. If some backwards
-  incompabile changes will be required, they'll have to go into a 2.0.0
+  incompatible changes will be required, they'll have to go into a 2.0.0
   branch.

--- a/doc/usbguard-rules.conf.5
+++ b/doc/usbguard-rules.conf.5
@@ -13,7 +13,7 @@ which is described in the \f[I]Rule Language\f[] section below.
 .PP
 The USBGuard daemon decides which USB device to authorize based on a
 policy defined by a set of rules.
-When an USB device is inserted into the system, the daemon scans the
+When a USB device is inserted into the system, the daemon scans the
 existing rules sequentially and when a matching rule is found, it either
 authorizes (\f[B]allows\f[]), deauthorizes (\f[B]blocks\f[]) or removes
 (\f[B]rejects\f[]) the device, based on the rule target.
@@ -62,7 +62,7 @@ Such a minimal rule will match any device and allows the policy creator
 to write an explicit default target.
 If no rule from the policy is applicable to the device, an implicit
 target configured in \f[B]usbguard\-daemon.conf\f[](5) will be used.
-However, if one want\[aq]s to narrow the applicability of a rule to a
+However, if one wants to narrow the applicability of a rule to a
 set of devices or one device only, it\[aq]s possible to do so with
 device attributes and rule conditions.
 .SS Device Attributes

--- a/doc/usbguard-rules.conf.5.md
+++ b/doc/usbguard-rules.conf.5.md
@@ -12,7 +12,7 @@ The **usbguard-rules.conf** file is loaded by the USBGuard daemon after it parse
 
 # Rule Language
 
-The USBGuard daemon decides which USB device to authorize based on a policy defined by a set of rules. When an USB device is inserted into the system, the daemon scans the existing rules sequentially and when a matching rule is found, it either authorizes (**allows**), deauthorizes (**blocks**) or removes (**rejects**) the device, based on the rule target. If no matching rule is found, the decision is based on an implicit default target. This implicit default is to block the device until a decision is made by the user. The rule language grammar, expressed in a BNF-like syntax, is the following:
+The USBGuard daemon decides which USB device to authorize based on a policy defined by a set of rules. When a USB device is inserted into the system, the daemon scans the existing rules sequentially and when a matching rule is found, it either authorizes (**allows**), deauthorizes (**blocks**) or removes (**rejects**) the device, based on the rule target. If no matching rule is found, the decision is based on an implicit default target. This implicit default is to block the device until a decision is made by the user. The rule language grammar, expressed in a BNF-like syntax, is the following:
 
 ```
     rule ::= target attributes.
@@ -35,7 +35,7 @@ The target of a rule specifies whether the device will be authorized for use or 
 
 ## Device Specification
 
-Except the target, all the other fields of a rule need not be specified. Such a minimal rule will match any device and allows the policy creator to write an explicit default target. If no rule from the policy is applicable to the device, an implicit target configured in **usbguard-daemon.conf**(5) will be used. However, if one want's to narrow the applicability of a rule to a set of devices or one device only, it's possible to do so with device attributes and rule conditions.
+Except the target, all the other fields of a rule need not be specified. Such a minimal rule will match any device and allows the policy creator to write an explicit default target. If no rule from the policy is applicable to the device, an implicit target configured in **usbguard-daemon.conf**(5) will be used. However, if one wants to narrow the applicability of a rule to a set of devices or one device only, it's possible to do so with device attributes and rule conditions.
 
 ### Device Attributes
 


### PR DESCRIPTION
Found using [mwic](http://jwilk.net/software/mwic) and [anorack](https://github.com/jwilk/anorack).