### PR TITLE
Qt Applet: disable session management

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -528,6 +528,8 @@ usbguard_applet_qt_SOURCES_BASE=\
 	src/GUI.Qt/MainWindow.h \
 	src/GUI.Qt/DeviceModel.cpp \
 	src/GUI.Qt/DeviceModel.h \
+	src/GUI.Qt/SessionBlocker.cpp \
+	src/GUI.Qt/SessionBlocker.h \
 	src/GUI.Qt/TargetDelegate.cpp \
 	src/GUI.Qt/TargetDelegate.h
 
@@ -564,6 +566,7 @@ CLEANFILES +=\
 	$(top_builddir)/src/GUI.Qt/usbguard.qrc.cpp \
 	$(top_builddir)/src/GUI.Qt/usbguard.qrc \
 	$(top_builddir)/src/GUI.Qt/DeviceModel.moc.cpp \
+	$(top_builddir)/src/GUI.Qt/SessionBlocker.moc.cpp \
 	$(top_builddir)/src/GUI.Qt/TargetDelegate.moc.cpp
 
 nodist_usbguard_applet_qt_SOURCES=\
@@ -572,6 +575,7 @@ nodist_usbguard_applet_qt_SOURCES=\
 	src/GUI.Qt/MainWindow.moc.cpp \
 	src/GUI.Qt/usbguard.qrc.cpp \
 	src/GUI.Qt/DeviceModel.moc.cpp \
+	src/GUI.Qt/SessionBlocker.moc.cpp \
 	src/GUI.Qt/TargetDelegate.moc.cpp
 
 usbguard_applet_qt_LDADD=\

--- a/src/GUI.Qt/SessionBlocker.cpp
+++ b/src/GUI.Qt/SessionBlocker.cpp
@@ -1,0 +1,31 @@
+//
+// Copyright (C) 2017 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Authors: Pino Toscano <toscano.pino@tiscali.it>
+//
+#include "SessionBlocker.h"
+
+SessionBlocker::SessionBlocker(QApplication& app) :
+    QObject(&app)
+{
+  connect(&app, SIGNAL(commitDataRequest(QSessionManager&)), SLOT(slotDisableSessionManagement(QSessionManager&)));
+  connect(&app, SIGNAL(saveStateRequest(QSessionManager&)), SLOT(slotDisableSessionManagement(QSessionManager&)));
+}
+
+void SessionBlocker::slotDisableSessionManagement(QSessionManager &sm)
+{
+  sm.setRestartHint(QSessionManager::RestartNever);
+}

--- a/src/GUI.Qt/SessionBlocker.h
+++ b/src/GUI.Qt/SessionBlocker.h
@@ -1,0 +1,35 @@
+//
+// Copyright (C) 2017 Red Hat, Inc.
+//
+// This program is free software; you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation; either version 2 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+//
+// Authors: Pino Toscano <toscano.pino@tiscali.it>
+//
+#pragma once
+
+#include <QApplication>
+#include <QObject>
+#include <QSessionManager>
+
+class SessionBlocker : public QObject
+{
+  Q_OBJECT
+
+public:
+  explicit SessionBlocker(QApplication& app);
+
+private slots:
+  void slotDisableSessionManagement(QSessionManager &sm);
+};
+

--- a/src/GUI.Qt/main.cpp
+++ b/src/GUI.Qt/main.cpp
@@ -17,6 +17,7 @@
 // Authors: Daniel Kopecek <dkopecek@redhat.com>
 //
 #include "MainWindow.h"
+#include "SessionBlocker.h"
 #include <Logger.hpp>
 #include <QApplication>
 #include <QLocale>
@@ -41,6 +42,8 @@ int main(int argc, char *argv[])
     else {
       USBGUARD_LOG(Debug) << "Translations not available for the current locale.";
     }
+
+    const SessionBlocker block(a);
 
     MainWindow w;
     a.setQuitOnLastWindowClosed(false);


### PR DESCRIPTION
The Qt applet has an autostart `.desktop` file, so it is started at each login of XDG-based environments; since the default session management in Qt applications is to save the application as part of the session,
this leads more instances of the Qt applet to run for each new session, in case the session configuration is to save & restore it.

The solution is to disable the session management for the Qt applet, so it will not be saved by the session manager.

Closes: #160