### PR TITLE
documentation: Add missing option and reorder

### DIFF
--- a/doc/usbguard-daemon.conf.5.md
+++ b/doc/usbguard-daemon.conf.5.md
@@ -30,6 +30,9 @@ The **usbguard-daemon.conf** file is loaded by the USBGuard daemon after it pars
 **RestoreControllerDeviceState**=<*boolean*>
 :   The USBGuard daemon modifies some attributes of controller devices like the default authorization state of new child device instances. Using this setting, you can control whether the daemon will try to restore the attribute values to the state before modification on shutdown.
 
+**DeviceManagerBackend**=<*backend*>
+:   Which device manager backend implementation to use. Backend should be one of `uevent` (default) or `dummy`.
+
 **IPCAllowedUsers**=<*username*> [<*username*> ...]
 :   A space delimited list of usernames that the daemon will accept IPC connections from.
 
@@ -37,13 +40,10 @@ The **usbguard-daemon.conf** file is loaded by the USBGuard daemon after it pars
 :   A space delimited list of groupnames that the daemon will accept IPC connections from.
 
 **IPCAccessControlFiles**=<*path*>
-:   Path to a directory holding the IPC access control files.
-
-**DeviceManagerBackend**=<*backend*>
-:   Which device manager backend implementation to use. Backend should be one of `uevent` (default) or `dummy`.
-
-**IPCAccessControlFiles**=<*path*>
 :   The files at this location will be interpreted by the daemon as IPC access control definition files. See the **IPC ACCESS CONTROL** section for more details.
+
+**DeviceRulesWithPort**=<*boolean*>
+:   Generate device specific rules including the "via-port" attribute.
 
 **AuditFilePath**=<*filepath*>
 :   USBGuard audit events log file path.


### PR DESCRIPTION
One option was not in same order as in the example daemon configuration
file. One option was in there twice. And one was missing.