### PR TITLE
Fix config parser

### DIFF
--- a/src/Library/ConfigFilePrivate.cpp
+++ b/src/Library/ConfigFilePrivate.cpp
@@ -149,7 +149,7 @@ namespace usbguard
       }
 
       std::string name = trim(config_line.substr(0, nv_separator));
-      std::string value = config_line.substr(nv_separator + 1);
+      std::string value = trim(config_line.substr(nv_separator + 1));
 
       if (!checkNVPair(name, value)) {
         throw Exception("Configuration", name, "unknown configuration directive");

--- a/src/Library/ConfigFilePrivate.cpp
+++ b/src/Library/ConfigFilePrivate.cpp
@@ -136,6 +136,12 @@ namespace usbguard
     while (std::getline(_stream, config_line)) {
       ++config_line_number;
       _lines.push_back(config_line);
+      config_line = trim(config_line);
+
+      if (config_line[0] == '#') {
+        continue;
+      }
+
       const size_t nv_separator = config_line.find_first_of("=");
 
       if (nv_separator == std::string::npos) {
@@ -144,10 +150,6 @@ namespace usbguard
 
       std::string name = trim(config_line.substr(0, nv_separator));
       std::string value = config_line.substr(nv_separator + 1);
-
-      if (name[0] == '#') {
-        continue;
-      }
 
       if (!checkNVPair(name, value)) {
         throw Exception("Configuration", name, "unknown configuration directive");


### PR DESCRIPTION
Hi,
in its current state, the config parser would reject empty lines and comments that do not include a '=' character as syntax errors, since the check for '=' happens **before** the check for the comment indicator.
I fixed that.
Also, I saw a small bug possibility in that the parser never trimmed the whitespace of the value section of the key=value pair, so key= value would've resulted in value being " value". I could not imagine a scenario in which this might be wanted or useful, so i added a trim() for that.
I'm using the master branch on my desktop machines since there still is no 4.13 compatible release.